### PR TITLE
Refatora `ser_vivo.c` para pipeline de semente mais robusto

### DIFF
--- a/ser_vivo.c
+++ b/ser_vivo.c
@@ -1,40 +1,74 @@
-#include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/wait.h>
+#include <unistd.h>
 
-int main() {
-
-    int fd;
-    char *dir = "ninho";
-    char *file = "ninho/semente.c";
-
-    char *code =
+int main(void) {
+    static const char dir[] = "ninho";
+    static const char file[] = "ninho/semente.c";
+    static const char bin[] = "ninho/semente";
+    static const char code[] =
         "#include <stdio.h>\n"
-        "int main(){ printf(\"O Vazio ecoa no Cheio.\\n\"); return 42; }\n";
+        "int main(void){ puts(\"O Vazio ecoa no Cheio.\"); return 42; }\n";
 
-    mkdir(dir, 0755);
-
-    fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-    write(fd, code, 120);
-    close(fd);
-
-    pid_t p = fork();
-
-    if (p == 0) {
-        char *args[] = {
-            "clang",
-            "-o",
-            "ninho/semente",
-            "ninho/semente.c",
-            NULL
-        };
-        execvp("clang", args);
+    if (mkdir(dir, 0755) < 0 && errno != EEXIST) {
+        perror("mkdir");
+        return 1;
     }
 
-    wait(NULL);
+    int fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open");
+        return 1;
+    }
 
-    char *run[] = { "ninho/semente", NULL };
-    execv("ninho/semente", run);
+    size_t total = sizeof(code) - 1U;
+    size_t off = 0;
+    while (off < total) {
+        ssize_t w = write(fd, code + off, total - off);
+        if (w < 0) {
+            perror("write");
+            close(fd);
+            return 1;
+        }
+        off += (size_t)w;
+    }
 
-    return 0;
+    if (close(fd) < 0) {
+        perror("close");
+        return 1;
+    }
+
+    pid_t p = fork();
+    if (p < 0) {
+        perror("fork");
+        return 1;
+    }
+
+    if (p == 0) {
+        char *const args[] = {"clang", "-O2", "-Wall", "-Wextra", "-std=c11", "-o", (char *)bin, (char *)file, NULL};
+        execvp("clang", args);
+        perror("execvp clang");
+        _exit(127);
+    }
+
+    int status = 0;
+    if (waitpid(p, &status, 0) < 0) {
+        perror("waitpid");
+        return 1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "clang falhou (status=%d)\n", status);
+        return 1;
+    }
+
+    char *const run[] = {(char *)bin, NULL};
+    execv(bin, run);
+    perror("execv");
+    return 1;
 }


### PR DESCRIPTION
### Motivation
- Tornar previsível e à prova de falhas o fluxo que gera, compila e executa a "semente" em `ninho/semente.c`. 
- Evitar corrupção/truncamento do arquivo causado por escrita com tamanho fixo e falhas silenciosas de I/O. 
- Melhorar tratamento de erros e conformidade com práticas C modernas para reduzir comportamento indefinido em produção. 

### Description
- Substitui escrita estática por um loop seguro de `write` que garante gravação completa do conteúdo de `code` em `ninho/semente.c` e fecha o descritor com verificação de erro. 
- Adiciona verificações de erro para `mkdir`, `open`, `write`, `close`, `fork`, `waitpid`, `execvp` e `execv` e retorna códigos apropriados em caso de falha. 
- Atualiza includes (`errno.h`, `sys/stat.h`, `sys/types.h`, `stdio.h`, etc.) e muda a assinatura para `int main(void)`. 
- Melhora o fluxo de compilação chamando `clang` com flags (`-O2 -Wall -Wextra -std=c11`), valida o status do compilador via `waitpid` e só executa o binário se a compilação for bem-sucedida. 

### Testing
- Compilação: `clang -O2 -Wall -Wextra -std=c11 ser_vivo.c -o /tmp/ser_vivo` foi executada com sucesso. 
- Execução: `/tmp/ser_vivo` imprimiu `O Vazio ecoa no Cheio.` e retornou código de saída `42`, indicando pipeline de geração/compilação/execução funcional.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec1215d934832da640810250cb0f1b)